### PR TITLE
Use instruction and peripheral instance names for Arm Cortex-M0+ interrupt vector table entries

### DIFF
--- a/docs/library_configuration.md
+++ b/docs/library_configuration.md
@@ -50,23 +50,23 @@ This header file is used to inject implementation interrupt handler entries into
 `picolibrary/arm/cortex/m0plus/implementation/interrupt/vectors.h` would be defined as
 follows for the Microchip SAM D21/DA1 family of Arm Cortex-M0+ microcontrollers:
 ```c++
-Handler pm_handler;
+Handler pm0_handler;
 
-Handler sysctrl_handler;
+Handler sysctrl0_handler;
 
-Handler wdt_handler;
+Handler wdt0_handler;
 
-Handler rtc_handler;
+Handler rtc0_handler;
 
-Handler eic_handler;
+Handler eic0_handler;
 
-Handler nvmctrl_handler;
+Handler nvmctrl0_handler;
 
-Handler dmac_handler;
+Handler dmac0_handler;
 
-Handler usb_handler;
+Handler usb0_handler;
 
-Handler evsys_handler;
+Handler evsys0_handler;
 
 Handler sercom0_handler;
 
@@ -96,15 +96,15 @@ Handler tc6_handler;
 
 Handler tc7_handler;
 
-Handler adc_handler;
+Handler adc0_handler;
 
-Handler ac_handler;
+Handler ac0_handler;
 
-Handler dac_handler;
+Handler dac0_handler;
 
-Handler ptc_handler;
+Handler ptc0_handler;
 
-Handler i2s_handler;
+Handler i2s0_handler;
 
 Handler ac1_handler;
 

--- a/include/picolibrary/arm/cortex/m0plus/interrupt.h
+++ b/include/picolibrary/arm/cortex/m0plus/interrupt.h
@@ -52,9 +52,9 @@ struct PICOLIBRARY_ARM_CORTEX_M0PLUS_INTERRUPT_VECTOR_TABLE_ALIGNMENT Vector_Tab
     Handler reset_handler;
 
     /**
-     * \brief Non-Maskable Interrupt (NMI) handler.
+     * \brief NMI handler.
      */
-    Handler nonmaskable_interrupt_handler;
+    Handler nmi_handler;
 
     /**
      * \brief Hard fault handler.
@@ -97,9 +97,9 @@ struct PICOLIBRARY_ARM_CORTEX_M0PLUS_INTERRUPT_VECTOR_TABLE_ALIGNMENT Vector_Tab
     Handler reserved_n6;
 
     /**
-     * \brief Supervisor Call (SVCALL) handler.
+     * \brief SVCALL handler.
      */
-    Handler supervisor_call_handler;
+    Handler svcall_handler;
 
     /**
      * \brief Reserved (IRQ -4).
@@ -112,15 +112,15 @@ struct PICOLIBRARY_ARM_CORTEX_M0PLUS_INTERRUPT_VECTOR_TABLE_ALIGNMENT Vector_Tab
     Handler reserved_n3;
 
     /**
-     * \brief Context Switch (PENDSV) handler.
+     * \brief PENDSV handler.
      */
-    Handler context_switch_handler;
+    Handler pendsv_handler;
 
 #if PICOLIBRARY_ARM_CORTEX_M0PLUS_IMPLEMENTATION_HAS_SYSTICK
     /**
-     * \brief System Tick (SYSTICK) handler.
+     * \brief SYSTICK0 handler.
      */
-    Handler system_tick_handler;
+    Handler systick0_handler;
 #else  // PICOLIBRARY_ARM_CORTEX_M0PLUS_IMPLEMENTATION_HAS_SYSTICK
     /**
      * \brief Reserved (IRQ -1).


### PR DESCRIPTION
Resolves #49 (Use instruction and peripheral instance names for Arm Cortex-M0+ interrupt vector table entries).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
